### PR TITLE
Test builing and linking extended

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ SET(NUCLEAR_ROLE_BANNER_FILE "${CMAKE_CURRENT_SOURCE_DIR}/roles/banner.png" CACH
 # Our location of our nuclear roles directory
 SET(NUCLEAR_ROLES_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE PATH "The path to the nuclear roles system directory")
 
+SET(NUCLEAR_ADDITIONAL_SHARED_LIBRARIES "" CACHE STRING "Additional libraries used when linking roles, extensions, and utilities")
+
+SET(NUCLEAR_TEST_LIBRARIES "" CACHE STRING "Additional libraries used when linking module tests")
+
 # Our variables that are used to locate the shared, module, and message folders
 # They are given relative to the current project directory
 SET(NUCLEAR_MODULE_DIR    "module"           CACHE PATH "The path to the module directory for NUClear")

--- a/module/NUClearModule.cmake
+++ b/module/NUClearModule.cmake
@@ -19,7 +19,7 @@ FUNCTION(NUCLEAR_MODULE)
     # Parse our input arguments
     SET(options, "")
     SET(oneValueArgs "LANGUAGE")
-    SET(multiValueArgs "INCLUDES" "LIBRARIES" "SOURCES" "DATA_FILES")
+    SET(multiValueArgs "INCLUDES" "LIBRARIES" "SOURCES" "DATA_FILES" "TEST_LIBRARIES")
     CMAKE_PARSE_ARGUMENTS(MODULE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     # Include our own source and binary directories
@@ -206,7 +206,7 @@ FUNCTION(NUCLEAR_MODULE)
         FILE(GLOB_RECURSE test_src "tests/**.cpp" "tests/**.cc" "tests/**.c" "tests/**.hpp" "tests/**.hh" "tests/**.h")
         IF(test_src)
           ADD_EXECUTABLE(${test_module_target_name} ${test_src})
-          TARGET_LINK_LIBRARIES(${test_module_target_name} ${module_target_name} ${LIBRARIES} ${NUCLEAR_TEST_LIBRARIES})
+          TARGET_LINK_LIBRARIES(${test_module_target_name} ${module_target_name} ${MODULE_TEST_LIBRARIES} ${NUCLEAR_TEST_LIBRARIES})
           
           SET_PROPERTY(TARGET ${test_module_target_name} PROPERTY FOLDER "modules/tests")
           

--- a/module/NUClearModule.cmake
+++ b/module/NUClearModule.cmake
@@ -203,7 +203,6 @@ FUNCTION(NUCLEAR_MODULE)
         SET(test_module_target_name "Test${module_target_name}")
 
         # Rebuild our sources using the test module
-        FILE(GLOB_RECURSE test_src "tests/**.cpp" "tests/**.h")
         ADD_EXECUTABLE(${test_module_target_name} ${test_src})
         TARGET_LINK_LIBRARIES(${test_module_target_name} ${module_target_name} ${LIBRARIES})
 
@@ -212,6 +211,7 @@ FUNCTION(NUCLEAR_MODULE)
         # Add the test
         ADD_TEST(${test_module_target_name} ${test_module_target_name})
 
+        FILE(GLOB_RECURSE test_src "tests/**.cpp" "tests/**.cc" "tests/**.c")
     ENDIF()
 
 ENDFUNCTION(NUCLEAR_MODULE)

--- a/module/NUClearModule.cmake
+++ b/module/NUClearModule.cmake
@@ -203,8 +203,6 @@ FUNCTION(NUCLEAR_MODULE)
         SET(test_module_target_name "Test${module_target_name}")
 
         # Rebuild our sources using the test module
-        ADD_TEST(${test_module_target_name} ${test_module_target_name})
-
         FILE(GLOB_RECURSE test_src "tests/**.cpp" "tests/**.cc" "tests/**.c")
         IF(test_src)
           ADD_EXECUTABLE(${test_module_target_name} ${test_src})
@@ -213,6 +211,8 @@ FUNCTION(NUCLEAR_MODULE)
           SET_PROPERTY(TARGET ${test_module_target_name} PROPERTY FOLDER "modules/tests")
           
           # Add the test
+          ADD_TEST(NAME ${test_module_target_name} WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${test_module_target_name})
+
         ENDIF()
     ENDIF()
 

--- a/module/NUClearModule.cmake
+++ b/module/NUClearModule.cmake
@@ -203,15 +203,17 @@ FUNCTION(NUCLEAR_MODULE)
         SET(test_module_target_name "Test${module_target_name}")
 
         # Rebuild our sources using the test module
-        ADD_EXECUTABLE(${test_module_target_name} ${test_src})
-        TARGET_LINK_LIBRARIES(${test_module_target_name} ${module_target_name} ${LIBRARIES})
-
-        SET_PROPERTY(TARGET ${test_module_target_name} PROPERTY FOLDER "modules/tests")
-
-        # Add the test
         ADD_TEST(${test_module_target_name} ${test_module_target_name})
 
         FILE(GLOB_RECURSE test_src "tests/**.cpp" "tests/**.cc" "tests/**.c")
+        IF(test_src)
+          ADD_EXECUTABLE(${test_module_target_name} ${test_src})
+          TARGET_LINK_LIBRARIES(${test_module_target_name} ${module_target_name} ${LIBRARIES})
+          
+          SET_PROPERTY(TARGET ${test_module_target_name} PROPERTY FOLDER "modules/tests")
+          
+          # Add the test
+        ENDIF()
     ENDIF()
 
 ENDFUNCTION(NUCLEAR_MODULE)

--- a/module/NUClearModule.cmake
+++ b/module/NUClearModule.cmake
@@ -206,7 +206,7 @@ FUNCTION(NUCLEAR_MODULE)
         FILE(GLOB_RECURSE test_src "tests/**.cpp" "tests/**.cc" "tests/**.c")
         IF(test_src)
           ADD_EXECUTABLE(${test_module_target_name} ${test_src})
-          TARGET_LINK_LIBRARIES(${test_module_target_name} ${module_target_name} ${LIBRARIES})
+          TARGET_LINK_LIBRARIES(${test_module_target_name} ${module_target_name} ${LIBRARIES} ${NUCLEAR_TEST_LIBRARIES})
           
           SET_PROPERTY(TARGET ${test_module_target_name} PROPERTY FOLDER "modules/tests")
           

--- a/module/NUClearModule.cmake
+++ b/module/NUClearModule.cmake
@@ -203,7 +203,7 @@ FUNCTION(NUCLEAR_MODULE)
         SET(test_module_target_name "Test${module_target_name}")
 
         # Rebuild our sources using the test module
-        FILE(GLOB_RECURSE test_src "tests/**.cpp" "tests/**.cc" "tests/**.c")
+        FILE(GLOB_RECURSE test_src "tests/**.cpp" "tests/**.cc" "tests/**.c" "tests/**.hpp" "tests/**.hh" "tests/**.h")
         IF(test_src)
           ADD_EXECUTABLE(${test_module_target_name} ${test_src})
           TARGET_LINK_LIBRARIES(${test_module_target_name} ${module_target_name} ${LIBRARIES} ${NUCLEAR_TEST_LIBRARIES})


### PR DESCRIPTION
* When trying to set up tests they wouldn't run due to not being able to find the module libraries they were linked against. Running them from the main build directory instead works.
* Added source extensions (and removed adding header files, CMake should find those automatically as dependencies)
* Handle if there are no source files
* Added option to pass additional libraries to link against (like gtest which we use)

For me the `PROPERTY FOLDER` doesn't do anything, I don't know if that'd interfere with something, or that line could go?